### PR TITLE
Replace NodeConnectionType enum with string literals in HtmlCssToImage

### DIFF
--- a/nodes/HtmlCssToImage/HtmlCssToImage.node.ts
+++ b/nodes/HtmlCssToImage/HtmlCssToImage.node.ts
@@ -4,7 +4,7 @@ import type {
 	INodeType,
 	INodeTypeDescription,
 } from 'n8n-workflow';
-import { NodeConnectionType, NodeOperationError } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
 
 export class HtmlCssToImage implements INodeType {
 	description: INodeTypeDescription = {
@@ -17,8 +17,8 @@ export class HtmlCssToImage implements INodeType {
 		defaults: {
 			name: 'HTML/CSS to Image',
 		},
-		inputs: [NodeConnectionType.Main],
-		outputs: [NodeConnectionType.Main],
+		inputs: ['main'],
+		outputs: ['main'],
 		credentials: [
 			{
 				name: 'htmlcsstoimgApi',


### PR DESCRIPTION
## Summary
Updated the HtmlCssToImage node to use string literals instead of the `NodeConnectionType` enum for input and output definitions, and removed the unused import.

## Key Changes
- Removed `NodeConnectionType` from the imports as it's no longer needed
- Changed `inputs: [NodeConnectionType.Main]` to `inputs: ['main']`
- Changed `outputs: [NodeConnectionType.Main]` to `outputs: ['main']`

## Details
This change aligns with a pattern of using string literals directly for node connection types instead of relying on the enum constant. This simplifies the code and reduces unnecessary imports while maintaining the same functionality.

https://claude.ai/code/session_01NBi35C71vHjneVan5hYsjh